### PR TITLE
Lose webgl context after test 

### DIFF
--- a/src/modules/system/provideCss/system.provideCss.js
+++ b/src/modules/system/provideCss/system.provideCss.js
@@ -12,10 +12,13 @@ ym.modules.define('system.provideCss', ['system.nextTick'], function (provide, n
      */
         tag,
         waitForNextTick = false,
-        inState=0;
+        inState = 0,
+        svgSaltPlace = 'charset=svgsalt-' + (new Date());
 
     provide(function (cssText, callback) {
-        newCssText += cssText + '\n/**/\n';
+        // В dataURI SVG может быть специальное место, для вставки уникального блока
+        // в целях "пробития" кеша в ИЕ. Иначе некоторые обьекты (метки) не отображаются. MAPSAPI-9741.
+        newCssText += cssText.replace(/svgSaltSeed/g, svgSaltPlace) + '\n/**/\n';
         callbacks.push(callback);
         //writeCSSModules();
         //return;
@@ -34,7 +37,7 @@ ym.modules.define('system.provideCss', ['system.nextTick'], function (provide, n
         if (!tag) {
             tag = document.createElement("style");
             tag.type = "text/css";
-            tag.setAttribute && tag.setAttribute('data-ymaps','css-modules');
+            tag.setAttribute && tag.setAttribute('data-ymaps', 'css-modules');
         }
 
         if (tag.styleSheet) {
@@ -48,13 +51,13 @@ ym.modules.define('system.provideCss', ['system.nextTick'], function (provide, n
             document.getElementsByTagName("head")[0].appendChild(tag);
             tag = null;
         }
-        inState=1;
+        inState = 1;
         newCssText = '';
-        var cb=callbacks;
-        callbacks=[];
+        var cb = callbacks;
+        callbacks = [];
         for (var i = 0, l = cb.length; i < l; ++i) {
             cb[i]();
         }
-        inState=0;
+        inState = 0;
     };
 });

--- a/src/modules/system/provideCss/system.provideCss.js
+++ b/src/modules/system/provideCss/system.provideCss.js
@@ -12,13 +12,10 @@ ym.modules.define('system.provideCss', ['system.nextTick'], function (provide, n
      */
         tag,
         waitForNextTick = false,
-        inState = 0,
-        svgSaltPlace = 'charset=svgsalt-' + (new Date());
+        inState = 0;
 
     provide(function (cssText, callback) {
-        // В dataURI SVG может быть специальное место, для вставки уникального блока
-        // в целях "пробития" кеша в ИЕ. Иначе некоторые обьекты (метки) не отображаются. MAPSAPI-9741.
-        newCssText += cssText.replace(/svgSaltSeed/g, svgSaltPlace) + '\n/**/\n';
+        newCssText += cssText + '\n/**/\n';
         callbacks.push(callback);
         //writeCSSModules();
         //return;

--- a/src/modules/system/supports/graphics/graphics.js
+++ b/src/modules/system/supports/graphics/graphics.js
@@ -22,9 +22,9 @@ ym.modules.define('system.supports.graphics', [], function (provide) {
         return WEBGL_CONTEXT_NAME;
     }
 
-    function testCanvas(sandbox, ctx){
-        sandbox.width=226;
-        sandbox.height=256;
+    function testCanvas (sandbox, ctx) {
+        sandbox.width = 226;
+        sandbox.height = 256;
 
         ctx.fillStyle = "#fff";
         ctx.fillRect(0, 0, 150, 150);
@@ -39,7 +39,7 @@ ym.modules.define('system.supports.graphics', [], function (provide) {
 
         var data = ctx.getImageData(49, 49, 2, 2),
             test = [];
-        for(var i=0;i<16;i++){
+        for (var i = 0; i < 16; i++) {
             test.push(data.data[i]);
         }
         return test.join('x') == '0x0x0x0x0x0x0x0x0x0x0x0x0x255x0x255';
@@ -75,6 +75,11 @@ ym.modules.define('system.supports.graphics', [], function (provide) {
                 var sandbox = document.createElement("canvas"),
                     context = ('getContext' in sandbox) ? sandbox.getContext(getWebglContextName(), glContextSettings) : false;
                 tests.webgl = context && typeof context.getParameter == "function";
+                if (tests.webgl) {
+                    // force lose context
+                    var lose = context.getExtension('WEBGL_lose_context');
+                    lose && lose.loseContext();
+                }
             }
             return tests.webgl;
         },


### PR DESCRIPTION
Fixing: WARNING: Too many active WebGL contexts. Oldest context will be lost.
